### PR TITLE
New backlight control mode for display that are too bright

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,6 @@ back-light control will be used.  This is most useful:
   - if the back-light control of your screen is working, but the
   lowest setting is still too bright.
 
-- If set to _Chain built-in, Blend external_, Blend mode will be used
-on external monitor and Chain mode will be used on built-in
-monitors.
-
 #### _Monitor(s)_
 
 - If set to _All_, a brightness overlay will be added to all attached

--- a/README.md
+++ b/README.md
@@ -118,10 +118,11 @@ if _Backlight control mode_ is in blend mode.
 When the brightness is set to 0%, the display will go completely dark,
 it may be hard to reset the brightness with the slider then.
 
-#### _Chain mode switching percentage_
+#### _Chain mode threshold_
 
-Sets the percentage at which the switch is made between soft
-brightness and backlight control in chain mode.
+Sets the brightness value between _0_ and _1_ at which the switch
+is made between soft brightness and backlight control in chain mode.
+Defaults to _0.3_ (30%).
 
 #### _Mouse cursor brightness control_
 

--- a/README.md
+++ b/README.md
@@ -38,23 +38,31 @@ page](https://extensions.gnome.org/local/).
 
 ### Configuration Settings
 
-#### _Use backlight control_
+#### _Backlight control mode_
 
-When enabled, Soft Brightness will work together with your computer's
-back-light.  The brightness slider and keyboard brightness hotkeys
-will control both the back-light and the Soft Brightness overlays.
-This is most useful:
+- If set to _Disabled_, the Brightness slider will only control the
+Soft Brightness overlays.  The keyboard brightness hotkeys will keep
+their default bindings.
 
-- if you have a back-light and  _Monitors_ is set to _External_, or
-
-- if a back-light is detected by Gnome but is not working (like some
+- If set to _Blend_, Soft Brightness will work together with your
+computer's back-light.  The brightness slider and keyboard brightness
+hotkeys will control both the back-light and the Soft Brightness
+overlays at the same time.  This is most useful:
+  - if you have a back-light and  _Monitors_ is set to _External_, or
+  - if a back-light is detected by Gnome but is not working (like some
   OLED panel laptops which report having a back-light brightness which
   doesn't exist).  In that latter case _Monitors_ should be set to
   _All_.
 
-If _Use backlight control_ is disabled, the Brightness slider will
-only control the Soft Brightness overlays.  The keyboard brightness
-hotkeys will keep their default bindings.
+- If set to _Chain_, Soft Brightness will be used for the lowest
+part of the slider.  Then over a given percentage of the slider,
+back-light control will be used.  This is most useful:
+  - if the back-light control of your screen is working, but the
+  lowest setting is still too bright.
+
+- If set to _Chain built-in, Blend external_, Blend mode will be used
+on external monitor and Chain mode will be used on built-in
+monitors.
 
 #### _Monitor(s)_
 
@@ -109,10 +117,15 @@ Sets the minimum allowable brightness for the display where _0_ is
 completely dark and _1_ completely bright. Defaults to _0.1_ (10%).
 
 The minimum brightness will also be enforced for the panel back-light
-if _Use backlight control_ is on.
+if _Backlight control mode_ is in blend mode.
 
 When the brightness is set to 0%, the display will go completely dark,
 it may be hard to reset the brightness with the slider then.
+
+#### _Chain mode switching percentage_
+
+Sets the percentage at which the switch is made between soft
+brightness and backlight control in chain mode.
 
 #### _Mouse cursor brightness control_
 
@@ -167,7 +180,7 @@ power usage.
 Soft Brightness can be used to control the brightness of all your
 attached monitors:
 
-- Set _Use backlight control_ to _Off_.
+- Set _Backlight control mode_ to _Disabled_.
 
 - Set _Monitor(s)_ to _All_.
 
@@ -177,7 +190,7 @@ You can leave the control of your attached display to the back-light
 and use Soft Brightness to control the brightness of external
 displays:
 
-- Set _Use backlight control_ to _On_.
+- Set _Backlight control mode_ to _Blend_.
 
 - Set _Monitor(s)_ to _External_.
 
@@ -188,7 +201,7 @@ displays:
 For example an OLED panel or non-functional back-light.  Have
 Soft-Brightness control the brightness for all your monitors:
 
-- Set _Use backlight control_ to _On_.
+- Set _Backlight control mode_ to _Blend_.
 
 - Set _Monitor(s)_ to _All_.
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ overlays at the same time.  This is most useful:
 
 - If set to _Chain_, Soft Brightness will be used for the lowest
 part of the slider.  Then over a given percentage of the slider,
-back-light control will be used.  This is most useful:
-  - if the back-light control of your screen is working, but the
-  lowest setting is still too bright.
+back-light control will be used.  The keyboard brightness hotkeys will
+only be applied on the back-light part of the slider.  This is most
+useful if the back-light control of your screen is working, but the
+lowest setting is still too bright.
 
 #### _Monitor(s)_
 
@@ -113,7 +114,7 @@ Sets the minimum allowable brightness for the display where _0_ is
 completely dark and _1_ completely bright. Defaults to _0.1_ (10%).
 
 The minimum brightness will also be enforced for the panel back-light
-if _Backlight control mode_ is in blend mode.
+if _Backlight control mode_ is in _Blend_ or _Chain_ mode.
 
 When the brightness is set to 0%, the display will go completely dark,
 it may be hard to reset the brightness with the slider then.
@@ -199,6 +200,17 @@ For example an OLED panel or non-functional back-light.  Have
 Soft-Brightness control the brightness for all your monitors:
 
 - Set _Backlight control mode_ to _Blend_.
+
+- Set _Monitor(s)_ to _All_.
+
+#### You have a laptop computer with a back-light too bright
+
+You can control back-light of your built-in display when brightness
+is over a threshold value. Then under it, back-light will be at
+minimum and Soft Brightness will be applied to darken all your screen
+even more:
+
+- Set _Backlight control mode_ to _Chain_.
 
 - Set _Monitor(s)_ to _All_.
 

--- a/schemas/org.gnome.shell.extensions.soft-brightness.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.soft-brightness.gschema.xml
@@ -20,11 +20,11 @@
       <summary>Backlight control mode.</summary>
       <description>If set to disabled, the Brightness slider will only
       control the Soft Brightness overlays.  If set to blend, Soft
-      Brightness will workntogether with your computer's back-light.
+      Brightness will work together with your computer's back-light.
       The brightness slider and keyboard brightness hotkeys will
       control both the back-light and the Soft Brightness overlays at
       the same time. If set to chain, Soft Brightness will be used
-      for the lowest part of the slider.  Then over a given
+      for the lowest part of the slider.  Then over a threshold
       percentage of the slider, back-light control will be used.
       </description>
     </key>
@@ -58,7 +58,7 @@
       <range min="0" max="1"/>
       <default>0.3</default>
       <summary>Chain mode threshold.</summary>
-      <description>Sets the brightness value between _0_ and _1_ at
+      <description>Sets the brightness value between 0 and 1 at
       which the switch is made between soft brightness and backlight
       control in chain mode.</description>
     </key>

--- a/schemas/org.gnome.shell.extensions.soft-brightness.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.soft-brightness.gschema.xml
@@ -13,7 +13,6 @@
     <value value="0" nick="disabled"/>
     <value value="1" nick="blend"/>
     <value value="2" nick="chain"/>
-    <value value="3" nick="hybrid"/>
   </enum>
   <schema id="org.gnome.shell.extensions.soft-brightness" path="/org/gnome/shell/extensions/soft-brightness/">
     <key name="backlight-mode" enum="org.gnome.shell.extensions.soft-brightness.backlight-modes">
@@ -26,9 +25,8 @@
       control both the back-light and the Soft Brightness overlays at
       the same time. If set to chain, Soft Brightness will be used
       for the lowest part of the slider.  Then over a given
-      percentage of the slider, back-light control will be used.  If
-      set to hybrid, blend mode will be used on external monitor and
-      chain mode will be used on built-in monitors.</description>
+      percentage of the slider, back-light control will be used.
+      </description>
     </key>
     <key name="monitors" enum="org.gnome.shell.extensions.soft-brightness.monitors">
       <default>"all"</default>

--- a/schemas/org.gnome.shell.extensions.soft-brightness.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.soft-brightness.gschema.xml
@@ -54,13 +54,13 @@
       <summary>Minimum brightness.</summary>
       <description>Minimum brightness level.</description>
     </key>
-    <key name="chain-mode-switch" type="d">
-      <range min="1" max="99"/>
-      <default>10</default>
-      <summary>Chain mode switching percentage.</summary>
-      <description>Sets the percentage at which the switch is made
-      between soft brightness and backlight control in chain mode..
-      </description>
+    <key name="chain-mode-threshold" type="d">
+      <range min="0" max="1"/>
+      <default>0.3</default>
+      <summary>Chain mode threshold.</summary>
+      <description>Sets the brightness value between _0_ and _1_ at
+      which the switch is made between soft brightness and backlight
+      control in chain mode.</description>
     </key>
     <key name="current-brightness" type="d">
       <range min="0" max="1"/>

--- a/schemas/org.gnome.shell.extensions.soft-brightness.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.soft-brightness.gschema.xml
@@ -9,11 +9,26 @@
     <value value="1" nick="when-correcting"/>
     <value value="2" nick="always"/>
   </enum>
+  <enum id="org.gnome.shell.extensions.soft-brightness.backlight-modes">
+    <value value="0" nick="disabled"/>
+    <value value="1" nick="blend"/>
+    <value value="2" nick="chain"/>
+    <value value="3" nick="hybrid"/>
+  </enum>
   <schema id="org.gnome.shell.extensions.soft-brightness" path="/org/gnome/shell/extensions/soft-brightness/">
-    <key name="use-backlight" type="b">
-      <default>false</default>
-      <summary>Use backlight control.</summary>
-      <description>Use the regular backlight control.</description>
+    <key name="backlight-mode" enum="org.gnome.shell.extensions.soft-brightness.backlight-modes">
+      <default>"disabled"</default>
+      <summary>Backlight control mode.</summary>
+      <description>If set to disabled, the Brightness slider will only
+      control the Soft Brightness overlays.  If set to blend, Soft
+      Brightness will workntogether with your computer's back-light.
+      The brightness slider and keyboard brightness hotkeys will
+      control both the back-light and the Soft Brightness overlays at
+      the same time. If set to chain, Soft Brightness will be used
+      for the lowest part of the slider.  Then over a given
+      percentage of the slider, back-light control will be used.  If
+      set to hybrid, blend mode will be used on external monitor and
+      chain mode will be used on built-in monitors.</description>
     </key>
     <key name="monitors" enum="org.gnome.shell.extensions.soft-brightness.monitors">
       <default>"all"</default>
@@ -40,6 +55,14 @@
       <default>0.1</default>
       <summary>Minimum brightness.</summary>
       <description>Minimum brightness level.</description>
+    </key>
+    <key name="chain-mode-switch" type="d">
+      <range min="1" max="99"/>
+      <default>10</default>
+      <summary>Chain mode switching percentage.</summary>
+      <description>Sets the percentage at which the switch is made
+      between soft brightness and backlight control in chain mode..
+      </description>
     </key>
     <key name="current-brightness" type="d">
       <range min="0" max="1"/>

--- a/src/extension.js
+++ b/src/extension.js
@@ -53,7 +53,6 @@ const ModifiedBrightnessIndicator = (function() {
 	    this._softBrightnessExtension._logger.log_debug("_sync()");
 	    this._softBrightnessExtension._on_brightness_change(false);
 	    this.setSliderValue(this._softBrightnessExtension._getBrightnessLevel());
-	    this.setSliderVBar(this._softBrightnessExtension._getSliderVBar());
 	}
 
 	setSliderValue(value) {
@@ -65,18 +64,6 @@ const ModifiedBrightnessIndicator = (function() {
 		// Gnome-Shell 3.33.90+
 		this._softBrightnessExtension._logger.log_debug("setSliderValue("+value+") [GS 3.33.90+]");
 		this._slider.value = value;
-	    }
-	}
-
-	setSliderVBar(percentage = null) {
-	    this._softBrightnessExtension._logger.log_debug("setSliderVBar("+percentage+") [GS 3.32-]");
-	    if (percentage !== null) {
-		// Slider vertical bar has been designed with "volume amplified"
-		// in mind. But it more logical for us to describe the position
-		// of the vertical bar in percentage, so we need to convert it.
-		this._slider.maximum_value = 100.0 / percentage;
-	    } else {
-		this._slider.maximum_value = null;
 	    }
 	}
     };
@@ -242,7 +229,6 @@ const SoftBrightnessExtension = class SoftBrightnessExtension {
 	if (! this._settings.get_string('backlight-mode') !== 'disabled' || this._brightnessIndicator._proxy.Brightness != null) {
 	    let curBrightness = this._getBrightnessLevel();
 	    this._brightnessIndicator.setSliderValue(curBrightness);
-	    this._brightnessIndicator.setSliderVBar(this._getSliderVBar());
 	    this._brightnessIndicator._sliderChanged(this._brightnessIndicator._slider);
 	}
 
@@ -481,13 +467,6 @@ const SoftBrightnessExtension = class SoftBrightnessExtension {
 	}
     }
 
-    _getSliderVBar() {
-	if (['chain', 'hybrid'].includes(this._settings.get_string('backlight-mode'))) {
-	    return this._settings.get_double('chain-mode-switch')
-	}
-	return null;
-    }
-
     // Settings monitoring
     _enableSettingsMonitoring() {
 	this._logger.log_debug('_enableSettingsMonitoring()');
@@ -554,8 +533,6 @@ const SoftBrightnessExtension = class SoftBrightnessExtension {
 
     _on_backlight_mode_change() {
 	this._logger.log_debug('_on_backlight_mode_change()');
-
-	this._brightnessIndicator.setSliderVBar(this._getSliderVBar())
 	if (this._settings.get_string('backlight-mode') !== 'disabled') {
 		this._storeBrightnessLevel(this._settings.get_double('current-brightness'));
 	} else if (this._brightnessIndicator._proxy.Brightness != null && this._brightnessIndicator._proxy.Brightness >= 0) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -477,8 +477,8 @@ const SoftBrightnessExtension = class SoftBrightnessExtension {
 		return brightness;
 	    } else {
 		const threshold = this._settings.get_double('chain-mode-threshold');
-		let convertedBrightness = brightness / 100.0 * (1.0 - threshold) + threshold
-		convertedBrightness = Math.min(1, Math.max(0, convertedBrightness))
+		let convertedBrightness = brightness / 100.0 * (1.0 - threshold) + threshold;
+		convertedBrightness = Math.min(1, Math.max(0, convertedBrightness));
 		this._logger.log_debug('_getBrightnessLevel() by chain mode proxy = '+convertedBrightness+' <- '+brightness);
 		return convertedBrightness;
 	    }
@@ -568,12 +568,12 @@ const SoftBrightnessExtension = class SoftBrightnessExtension {
     _on_backlight_mode_change() {
 	this._logger.log_debug('_on_backlight_mode_change()');
 	if (this._settings.get_string('backlight-mode') !== 'disabled') {
-		this._storeBrightnessLevel(this._settings.get_double('current-brightness'));
+	    this._storeBrightnessLevel(this._settings.get_double('current-brightness'));
 	} else if (this._brightnessIndicator._proxy.Brightness != null && this._brightnessIndicator._proxy.Brightness >= 0) {
 	    this._storeBrightnessLevel(this._brightnessIndicator._proxy.Brightness / 100.0);
 	}
     }
-	
+
     // Monitor change handling
     _enableMonitor2ing() {
 	this._logger.log_debug('_enableMonitor2ing()');

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -89,7 +89,6 @@ const SoftBrightnessSettings = GObject.registerClass(class SoftBrightnessSetting
 	this.backlight_control.append("disabled", _("Disabled"));
 	this.backlight_control.append("blend", _("Blend"));
 	this.backlight_control.append("chain", _("Chain"));
-	this.backlight_control.append("hybrid", _("Chain built-in, Blend external"));
 	this._settings.bind('backlight-mode', this.backlight_control, 'active-id', Gio.SettingsBindFlags.DEFAULT);
 	this.attach(this.backlight_label,   1, ypos, 1, 1);
 	this.attach(this.backlight_control, 2, ypos, 1, 1);

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -165,22 +165,22 @@ const SoftBrightnessSettings = GObject.registerClass(class SoftBrightnessSetting
 
 	ypos += 1;
 
-	descr = _(this._settings.settings_schema.get_key('chain-mode-switch').get_description());
-	this.chain_percentage_label = new Gtk.Label({label: _("Chain mode switching percentage (1..99):"), halign: Gtk.Align.START});
+	descr = _(this._settings.settings_schema.get_key('chain-mode-threshold').get_description());
+	this.chain_percentage_label = new Gtk.Label({label: _("Chain mode threshold (0..1):"), halign: Gtk.Align.START});
 	this.chain_percentage_label.set_tooltip_text(descr);
 	this.chain_percentage_control = new Gtk.SpinButton({
 	    halign: Gtk.Align.END,
-	    digits: 0,
+	    digits: 2,
 	    adjustment: new Gtk.Adjustment({
-		lower: 1.0,
-		upper: 99.0,
-		step_increment: 1
+		lower: 0.0,
+		upper: 1.0,
+		step_increment: 0.01
 	    })
 	});
 	this.chain_percentage_control.set_tooltip_text(descr);
 	this.attach(this.chain_percentage_label,   1, ypos, 1, 1);
 	this.attach(this.chain_percentage_control, 2, ypos, 1, 1);
-	this._settings.bind('chain-mode-switch', this.chain_percentage_control, 'value', Gio.SettingsBindFlags.DEFAULT);
+	this._settings.bind('chain-mode-threshold', this.chain_percentage_control, 'value', Gio.SettingsBindFlags.DEFAULT);
 
 	ypos += 1;
 

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -81,14 +81,18 @@ const SoftBrightnessSettings = GObject.registerClass(class SoftBrightnessSetting
 
 	ypos += 1;
 
-	descr = _(this._settings.settings_schema.get_key('use-backlight').get_description());
-	this.enabled_label = new Gtk.Label({label: _("Use backlight control:"), halign: Gtk.Align.START});
-	this.enabled_label.set_tooltip_text(descr);
-	this.enabled_control = new Gtk.Switch({halign: Gtk.Align.END});
-	this.enabled_control.set_tooltip_text(descr);
-	this.attach(this.enabled_label,   1, ypos, 1, 1);
-	this.attach(this.enabled_control, 2, ypos, 1, 1);
-	this._settings.bind('use-backlight', this.enabled_control, 'active', Gio.SettingsBindFlags.DEFAULT);
+	descr = _(this._settings.settings_schema.get_key('backlight-mode').get_description());
+	this.backlight_label = new Gtk.Label({label: _("Backlight control mode:"), halign: Gtk.Align.START});
+	this.backlight_label.set_tooltip_text(descr);
+	this.backlight_control = new Gtk.ComboBoxText({halign: Gtk.Align.END});
+	this.backlight_control.set_tooltip_text(descr);
+	this.backlight_control.append("disabled", _("Disabled"));
+	this.backlight_control.append("blend", _("Blend"));
+	this.backlight_control.append("chain", _("Chain"));
+	this.backlight_control.append("hybrid", _("Chain built-in, Blend external"));
+	this._settings.bind('backlight-mode', this.backlight_control, 'active-id', Gio.SettingsBindFlags.DEFAULT);
+	this.attach(this.backlight_label,   1, ypos, 1, 1);
+	this.attach(this.backlight_control, 2, ypos, 1, 1);
 
 	ypos += 1;
 
@@ -159,6 +163,25 @@ const SoftBrightnessSettings = GObject.registerClass(class SoftBrightnessSetting
 	this.attach(this.min_brightness_label,   1, ypos, 1, 1);
 	this.attach(this.min_brightness_control, 2, ypos, 1, 1);
 	this._settings.bind('min-brightness', this.min_brightness_control, 'value', Gio.SettingsBindFlags.DEFAULT);
+
+	ypos += 1;
+
+	descr = _(this._settings.settings_schema.get_key('chain-mode-switch').get_description());
+	this.chain_percentage_label = new Gtk.Label({label: _("Chain mode switching percentage (1..99):"), halign: Gtk.Align.START});
+	this.chain_percentage_label.set_tooltip_text(descr);
+	this.chain_percentage_control = new Gtk.SpinButton({
+	    halign: Gtk.Align.END,
+	    digits: 0,
+	    adjustment: new Gtk.Adjustment({
+		lower: 1.0,
+		upper: 99.0,
+		step_increment: 1
+	    })
+	});
+	this.chain_percentage_control.set_tooltip_text(descr);
+	this.attach(this.chain_percentage_label,   1, ypos, 1, 1);
+	this.attach(this.chain_percentage_control, 2, ypos, 1, 1);
+	this._settings.bind('chain-mode-switch', this.chain_percentage_control, 'value', Gio.SettingsBindFlags.DEFAULT);
 
 	ypos += 1;
 


### PR DESCRIPTION
Hello,
First of all, thank your for your great work, it's a pretty good extension that I will use a lot!

My use case is probably a bit different than your original idea. My laptop back-light work without trouble, however when set at the minimum value, brightness is still too bright.

So I modified the extension to replace the `use backlight` setting with `Back-light control mode`:
* Disabled: This is the current "use backlight : No"
* Blend: This is the current "use backlight : Yes". Backlight and soft brightness are change in parallel.
* Chain: This is the new mode. The laptop backlight setting is used when slider is over a threshold value, and soft brightness is used when under it.

Have a great day!